### PR TITLE
Remove dependency on MallocTracker for runtime

### DIFF
--- a/cacheray/CMakeLists.txt
+++ b/cacheray/CMakeLists.txt
@@ -2,16 +2,6 @@ cmake_minimum_required(VERSION 3.5)
 
 project(cacheray)
 
-message("LLVM_DIR:" $ENV{LLVM_DIR})
-if(NOT DEFINED ENV{LLVM_DIR})
-    message(SEND_MESSAGE "LLVM_DIR is not defined. Please add the LLVM_DIR environment variable.")
-endif()
-
-message("LLVM_BUILD_DIR: " $ENV{LLVM_BUILD_DIR})
-if(NOT DEFINED ENV{LLVM_BUILD_DIR})
-    message(SEND_MESSAGE "LLVM_BUILD_DIR is not defined. Please define it.")
-endif()
-
 set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib)
 set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib)
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin)
@@ -22,17 +12,10 @@ add_library(cacheray STATIC
         src/cacheray.c
         src/cacheray-utils.c )
 
-#add_definitions(-DDEBUG)
-
 target_include_directories(cacheray
         PUBLIC
         ${PROJECT_SOURCE_DIR}/include)
 
-if(DEFINED ENV{LLVM_DIR} AND DEFINED ENV{LLVM_BUILD_DIR})
-    add_subdirectory(test)
-endif()
-
+add_subdirectory(test)
 add_subdirectory(tracecheck)
-
-
 

--- a/cacheray/test/CMakeLists.txt
+++ b/cacheray/test/CMakeLists.txt
@@ -1,13 +1,6 @@
 cmake_minimum_required (VERSION 3.5)
 
 project(tests)
-#set(C_FLAGS -fsanitize=thread -O0 -g)
-set(ASM_FLAGS "") # Could be used for some linker specific flags    
-
-add_definitions(
-    -Xclang -load
-    -Xclang $ENV{LLVM_BUILD_DIR}/lib/LLVMMallocTracker.so
-    )
 
 add_definitions(-fsanitize=thread -O0 -g)
 


### PR DESCRIPTION
Compilation should be easier now. The test could also be amended to
use manual RTTA markings.

Used rebase this time, should be better...