### PR TITLE
Add install option for cacheray library

### DIFF
--- a/cacheray/CMakeLists.txt
+++ b/cacheray/CMakeLists.txt
@@ -19,3 +19,5 @@ target_include_directories(cacheray
 add_subdirectory(test)
 add_subdirectory(tracecheck)
 
+install(TARGETS cacheray DESTINATION lib)
+install(DIRECTORY ${CMAKE_SOURCE_DIR}/include/ DESTINATION include FILES_MATCHING PATTERN "*.h")


### PR DESCRIPTION
Cacheray may now be installed onto the the host system using e.g.
"make install".