### PR TITLE
Basic CI + format check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,33 @@
+name: Cacheray CI
+
+on:
+  - push
+  - pull_request
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  build:
+    runs-on: ubuntu-18.04
+    strategy:
+      fail-fast: false
+
+    steps:
+      - name: Install prerequisites
+        run: |
+          wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | sudo apt-key add -
+          sudo add-apt-repository "deb http://apt.llvm.org/bionic/ llvm-toolchain-bionic main"
+          sudo apt update
+          sudo apt install -y clang
+
+      - name: Check out default branch
+        uses: actions/checkout@v2
+
+      - name: Build Cacheray runtime
+        run: |
+          mkdir build
+          cd ./build
+          cmake -G "Unix Makefiles" -DCMAKE_C_COMPILER=clang ../cacheray
+          make

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,6 +21,7 @@ jobs:
           sudo add-apt-repository "deb http://apt.llvm.org/bionic/ llvm-toolchain-bionic main"
           sudo apt update
           sudo apt install -y clang
+          sudo apt install -y clang-format
 
       - name: Check out default branch
         uses: actions/checkout@v2
@@ -31,3 +32,16 @@ jobs:
           cd ./build
           cmake -G "Unix Makefiles" -DCMAKE_C_COMPILER=clang ../cacheray
           make
+
+      - name: Check format
+        run: |
+          git ls-files *.[ch] *.inc | xargs -l1 clang-format -i
+          git diff --exit-code > format.diff
+          git reset --hard
+
+      - name: Upload format diff
+        uses: actions/upload-artifact@v2
+        if: failure()
+        with:
+          name: format.diff
+          path: ./format.diff

--- a/cacheray/src/cacheray-utils.c
+++ b/cacheray/src/cacheray-utils.c
@@ -47,7 +47,6 @@ int cacheray_check_trace(FILE *trace_file, cacheray_access_stats_t *stats) {
       return CACHERAY_CHECK_WRONG_TYPE;
     };
 
-
     /* Update stats */
     if (stats) {
       if (stats->accs[ch] == -1) {

--- a/cacheray/test/grand/grand.c
+++ b/cacheray/test/grand/grand.c
@@ -1,10 +1,8 @@
 #include <stdio.h>
 #include <stdlib.h>
 
-#include <cacheray/cacheray.h>
 #include <cacheray/cacheray-utils.h>
-
-
+#include <cacheray/cacheray.h>
 
 /*
  * Here are the structs that we are working with:
@@ -40,7 +38,7 @@ int main(int argc, char **argv) {
   // LL creation
   struct Link *curr = NULL;
   struct Link *prev = NULL;
-  for(int i = 0; i < LINK_LENGTH; i++) {
+  for (int i = 0; i < LINK_LENGTH; i++) {
     curr = malloc(sizeof(struct Link));
     curr->data = i;
     curr->next = prev;

--- a/cacheray/tracecheck/cacheray-trace-check.c
+++ b/cacheray/tracecheck/cacheray-trace-check.c
@@ -17,7 +17,7 @@ int main(int argc, char **argv) {
   }
 
   // Init all stats to -1, so we can see which were incremented.
-  //memset(stats->accs, -1, sizeof(stats->accs) / sizeof(stats->accs[0]));
+  // memset(stats->accs, -1, sizeof(stats->accs) / sizeof(stats->accs[0]));
   for (int i = 0; i < UINT8_MAX; i++) {
     stats->accs[i] = -1;
   }

--- a/testbench/reorder/reorder.c
+++ b/testbench/reorder/reorder.c
@@ -2,11 +2,11 @@
 #include <stdlib.h>
 
 #ifdef USE_CACHERAY
-#include "cacheray/cacheray.h"
 #include "cacheray/cacheray-utils.h"
+#include "cacheray/cacheray.h"
 #endif
 
-#define LOG_SIZE_MAX (1<<27)
+#define LOG_SIZE_MAX (1 << 27)
 
 #define N (1024)
 #define M (1024)
@@ -14,64 +14,61 @@
 #define B_SIZE (64)
 
 struct OrderA {
-    int a;
-    char pad[B_SIZE - sizeof(int)];
-    int b;
-    char pad2[B_SIZE - sizeof(int)];
+  int a;
+  char pad[B_SIZE - sizeof(int)];
+  int b;
+  char pad2[B_SIZE - sizeof(int)];
 };
 
 struct OrderB {
-    int a;
-    int b;
-    char pad[B_SIZE - sizeof(int)];
-    char pad2[B_SIZE - sizeof(int)];
+  int a;
+  int b;
+  char pad[B_SIZE - sizeof(int)];
+  char pad2[B_SIZE - sizeof(int)];
 };
 
 typedef struct OrderA order_a_t;
 typedef struct OrderB order_b_t;
 
-void loop_A(order_a_t *list)
-{
-    for (unsigned int mult = 0; mult < M; mult++) {
-        for (unsigned int i = ASSOC; i < N; i++) {
-            list[i].a = list[i].a + list[i - ASSOC].b; 
-            list[i].b = list[i].b + list[i - ASSOC].a;
-        }
+void loop_A(order_a_t *list) {
+  for (unsigned int mult = 0; mult < M; mult++) {
+    for (unsigned int i = ASSOC; i < N; i++) {
+      list[i].a = list[i].a + list[i - ASSOC].b;
+      list[i].b = list[i].b + list[i - ASSOC].a;
     }
+  }
 }
 
-void loop_B(order_b_t *list)
-{
-    for (unsigned int mult = 0; mult < M; mult++) {
-        for (unsigned int i = ASSOC; i < N; i++) {
-            list[i].a = list[i].a + list[i - ASSOC].b; 
-            list[i].b = list[i].b + list[i - ASSOC].a; 
-        }
+void loop_B(order_b_t *list) {
+  for (unsigned int mult = 0; mult < M; mult++) {
+    for (unsigned int i = ASSOC; i < N; i++) {
+      list[i].a = list[i].a + list[i - ASSOC].b;
+      list[i].b = list[i].b + list[i - ASSOC].a;
     }
+  }
 }
 
-int main(int argc, char **argv)
-{
-    if (argc < 2) {
-        printf("Need arg\n");
-        return -1;
-    }
+int main(int argc, char **argv) {
+  if (argc < 2) {
+    printf("Need arg\n");
+    return -1;
+  }
 #ifdef USE_CACHERAY
-    cacheray_util_simple_log_begin(LOG_SIZE_MAX);
+  cacheray_util_simple_log_begin(LOG_SIZE_MAX);
 #endif
-    if (argv[1][0] == 'b') {
-        order_a_t *list = calloc(N*M, sizeof(order_a_t));
-        //cacheray_rtta_add(list, "order_a_t", sizeof(order_a_t), N*8);
-        loop_A(list);
-        free(list);
-    } else {
-        order_b_t *list = calloc(N*M, sizeof(order_b_t));
-        //cacheray_rtta_add(list, "order_b_t", sizeof(order_a_t), N*8);
-        loop_B(list);
-        free(list);
-    }
+  if (argv[1][0] == 'b') {
+    order_a_t *list = calloc(N * M, sizeof(order_a_t));
+    // cacheray_rtta_add(list, "order_a_t", sizeof(order_a_t), N*8);
+    loop_A(list);
+    free(list);
+  } else {
+    order_b_t *list = calloc(N * M, sizeof(order_b_t));
+    // cacheray_rtta_add(list, "order_b_t", sizeof(order_a_t), N*8);
+    loop_B(list);
+    free(list);
+  }
 #ifdef USE_CACHERAY
-    cacheray_util_simple_log_end();
+  cacheray_util_simple_log_end();
 #endif
-    return 0;
+  return 0;
 }

--- a/testbench/simple/simple-mt.c
+++ b/testbench/simple/simple-mt.c
@@ -1,55 +1,57 @@
 #include <stdio.h>
 #include <stdlib.h>
 
-#include "cacheray/cacheray.h"
 #include "cacheray/cacheray-utils.h"
+#include "cacheray/cacheray.h"
 
 #define COLUMNS 1024
 
-#define LOG_SIZE_MAX (1<<26)
+#define LOG_SIZE_MAX (1 << 26)
 
 struct node {
-    short a;
-    short b;
+  short a;
+  short b;
 };
 
 typedef struct node node_t;
 
 void by_row(node_t *data, unsigned nrows) {
-	for (unsigned r = 1; r < nrows; r++) {
-		for (unsigned c = 0; c < COLUMNS; c++) {
-            data[r * COLUMNS + c].a += data[(r - 1) * COLUMNS + c].b;
-			data[r * COLUMNS + c].b += data[(r - 1) * COLUMNS + c].a;
-		}
-	}
+  for (unsigned r = 1; r < nrows; r++) {
+    for (unsigned c = 0; c < COLUMNS; c++) {
+      data[r * COLUMNS + c].a += data[(r - 1) * COLUMNS + c].b;
+      data[r * COLUMNS + c].b += data[(r - 1) * COLUMNS + c].a;
+    }
+  }
 }
 void by_column(node_t *data, unsigned nrows) {
-	for (unsigned c = 0; c < COLUMNS; c++) {
-		for (unsigned r = 1; r < nrows; r++) {
-			data[r * COLUMNS + c].a = data[r * COLUMNS + c].a + data[(r - 1) * COLUMNS + c].b;
-			data[r * COLUMNS + c].b = data[r * COLUMNS + c].b + data[(r - 1) * COLUMNS + c].a;
-		}
-	}
+  for (unsigned c = 0; c < COLUMNS; c++) {
+    for (unsigned r = 1; r < nrows; r++) {
+      data[r * COLUMNS + c].a =
+          data[r * COLUMNS + c].a + data[(r - 1) * COLUMNS + c].b;
+      data[r * COLUMNS + c].b =
+          data[r * COLUMNS + c].b + data[(r - 1) * COLUMNS + c].a;
+    }
+  }
 }
 
-int main(int argc, char **argv){
-	if (argc < 2){
-		printf("Needs an arg");
-    }
-    unsigned rows = 64;
+int main(int argc, char **argv) {
+  if (argc < 2) {
+    printf("Needs an arg");
+  }
+  unsigned rows = 64;
 
-    cacheray_util_simple_log_begin(LOG_SIZE_MAX);
-    node_t *data = calloc(COLUMNS*rows, sizeof(node_t));
+  cacheray_util_simple_log_begin(LOG_SIZE_MAX);
+  node_t *data = calloc(COLUMNS * rows, sizeof(node_t));
 
-    if (argv[1][0] == 'g') { // good
-        by_row(data, rows);
-    } else if (argv[1][0] == 'b'){
-        by_column(data, rows);
-    } else {
-        printf("Need b or g\n");
-    }
+  if (argv[1][0] == 'g') { // good
+    by_row(data, rows);
+  } else if (argv[1][0] == 'b') {
+    by_column(data, rows);
+  } else {
+    printf("Need b or g\n");
+  }
 
-    free(data);
-    cacheray_util_simple_log_end();
-    return 0;
+  free(data);
+  cacheray_util_simple_log_end();
+  return 0;
 }

--- a/testbench/simple/simple-no-instrum.c
+++ b/testbench/simple/simple-no-instrum.c
@@ -6,54 +6,54 @@
 
 #define COLUMNS 1024
 
-#define LOG_SIZE_MAX (1<<26)
+#define LOG_SIZE_MAX (1 << 26)
 
 struct node {
-    short a;
-    short b;
+  short a;
+  short b;
 };
 
 typedef struct node node_t;
 
 void by_row(node_t *data, unsigned nrows) {
-	for (unsigned r = 1; r < nrows; r++) {
-		for (unsigned c = 0; c < COLUMNS; c++) {
-            data[r * COLUMNS + c].a += data[(r - 1) * COLUMNS + c].b;
-			data[r * COLUMNS + c].b += data[(r - 1) * COLUMNS + c].a;
-		}
-	}
+  for (unsigned r = 1; r < nrows; r++) {
+    for (unsigned c = 0; c < COLUMNS; c++) {
+      data[r * COLUMNS + c].a += data[(r - 1) * COLUMNS + c].b;
+      data[r * COLUMNS + c].b += data[(r - 1) * COLUMNS + c].a;
+    }
+  }
 }
 void by_column(node_t *data, unsigned nrows) {
-	for (unsigned c = 0; c < COLUMNS; c++) {
-		for (unsigned r = 1; r < nrows; r++) {
-			data[r * COLUMNS + c].a += data[(r - 1) * COLUMNS + c].b;
-			data[r * COLUMNS + c].b += data[(r - 1) * COLUMNS + c].a;
-		}
-	}
+  for (unsigned c = 0; c < COLUMNS; c++) {
+    for (unsigned r = 1; r < nrows; r++) {
+      data[r * COLUMNS + c].a += data[(r - 1) * COLUMNS + c].b;
+      data[r * COLUMNS + c].b += data[(r - 1) * COLUMNS + c].a;
+    }
+  }
 }
 
-int main(int argc, char **argv){
-	if (argc < 2){
-		printf("Needs an arg");
-    }
-    unsigned rows = 1024;
+int main(int argc, char **argv) {
+  if (argc < 2) {
+    printf("Needs an arg");
+  }
+  unsigned rows = 1024;
 
-    node_t *data = malloc(sizeof(node_t)*COLUMNS*rows);
+  node_t *data = malloc(sizeof(node_t) * COLUMNS * rows);
 
   //  cacheray_util_simple_log_begin(LOG_SIZE_MAX);
   //  cacheray_rtta_add(data, "node_t", sizeof(node_t), COLUMNS*rows);
 
-    if (argv[1][0] == 'g') { // good
-        by_row(data, rows);
-    } else if (argv[1][0] == 'b'){
-        by_column(data, rows);
-    } else {
-        printf("Need b or g\n");
-    }
+  if (argv[1][0] == 'g') { // good
+    by_row(data, rows);
+  } else if (argv[1][0] == 'b') {
+    by_column(data, rows);
+  } else {
+    printf("Need b or g\n");
+  }
 
-//    cacheray_util_simple_log_end();
+  //    cacheray_util_simple_log_end();
 
-    free(data);
+  free(data);
 
-    return 0;
+  return 0;
 }

--- a/testbench/simple/simple.c
+++ b/testbench/simple/simple.c
@@ -3,67 +3,67 @@
 
 #ifdef USE_CACHERAY
 
-#include "cacheray/cacheray.h"
 #include "cacheray/cacheray-utils.h"
+#include "cacheray/cacheray.h"
 
 #endif
 
 #define COLUMNS 1024
 
-#define LOG_SIZE_MAX (1<<27)
+#define LOG_SIZE_MAX (1 << 27)
 
 struct node {
-    short a;
-    short b;
+  short a;
+  short b;
 };
 
 typedef struct node node_t;
 
 void by_row(node_t *data, unsigned nrows) {
-	for (unsigned r = 1; r < nrows; r++) {
-		for (unsigned c = 0; c < COLUMNS; c++) {
-            data[r * COLUMNS + c].a += data[(r - 1) * COLUMNS + c].b;
-			data[r * COLUMNS + c].b += data[(r - 1) * COLUMNS + c].a;
-		}
-	}
+  for (unsigned r = 1; r < nrows; r++) {
+    for (unsigned c = 0; c < COLUMNS; c++) {
+      data[r * COLUMNS + c].a += data[(r - 1) * COLUMNS + c].b;
+      data[r * COLUMNS + c].b += data[(r - 1) * COLUMNS + c].a;
+    }
+  }
 }
 void by_column(node_t *data, unsigned nrows) {
-	for (unsigned c = 0; c < COLUMNS; c++) {
-		for (unsigned r = 1; r < nrows; r++) {
-			data[r * COLUMNS + c].a = data[r * COLUMNS + c].a + data[(r - 1) * COLUMNS + c].b;
-			data[r * COLUMNS + c].b = data[r * COLUMNS + c].b + data[(r - 1) * COLUMNS + c].a;
-		}
-	}
+  for (unsigned c = 0; c < COLUMNS; c++) {
+    for (unsigned r = 1; r < nrows; r++) {
+      data[r * COLUMNS + c].a =
+          data[r * COLUMNS + c].a + data[(r - 1) * COLUMNS + c].b;
+      data[r * COLUMNS + c].b =
+          data[r * COLUMNS + c].b + data[(r - 1) * COLUMNS + c].a;
+    }
+  }
 }
 
-int main(int argc, char **argv){
-	if (argc < 2) {
-		printf("Needs an arg");
-    }
-    unsigned rows = 1024;
+int main(int argc, char **argv) {
+  if (argc < 2) {
+    printf("Needs an arg");
+  }
+  unsigned rows = 1024;
 
-    node_t *data = malloc(sizeof(node_t)*COLUMNS*rows);
-
-#ifdef USE_CACHERAY
-    cacheray_util_simple_log_begin(LOG_SIZE_MAX);
-#endif
-
-    if (argv[1][0] == 'g') { 
-        // good
-        by_row(data, rows);
-    } 
-    else if (argv[1][0] == 'b') {
-        // bad
-        by_column(data, rows);
-    } 
-    else {
-        printf("Need b or g\n");
-    }
-    free(data);
+  node_t *data = malloc(sizeof(node_t) * COLUMNS * rows);
 
 #ifdef USE_CACHERAY
-    cacheray_util_simple_log_end();
+  cacheray_util_simple_log_begin(LOG_SIZE_MAX);
 #endif
 
-    return 0;
+  if (argv[1][0] == 'g') {
+    // good
+    by_row(data, rows);
+  } else if (argv[1][0] == 'b') {
+    // bad
+    by_column(data, rows);
+  } else {
+    printf("Need b or g\n");
+  }
+  free(data);
+
+#ifdef USE_CACHERAY
+  cacheray_util_simple_log_end();
+#endif
+
+  return 0;
 }


### PR DESCRIPTION
Hey,

This may look like a big change, but it comes in three parts;

1) Add basic CI that builds the runtime for every push/pull request (small)
2) Reformat all C code that's escaped the clutches of clang-format too long (big, but mechanical)
3) Add a CI step that checks formatting (small)

That way it's now impossible to merge code that violates the `.clang-format` spec.