### PR TITLE
Add sanitizer-like options parser

### DIFF
--- a/cacheray/CMakeLists.txt
+++ b/cacheray/CMakeLists.txt
@@ -10,6 +10,7 @@ set(CMAKE_C_STANDARD 11)
 
 add_library(cacheray STATIC
   src/cacheray.c
+  src/cacheray_options.c
 )
 
 target_include_directories(cacheray

--- a/cacheray/include/cacheray/cacheray_options.h
+++ b/cacheray/include/cacheray/cacheray_options.h
@@ -1,0 +1,19 @@
+#ifndef CACHERAY_OPTIONS_H_INCLUDED
+#define CACHERAY_OPTIONS_H_INCLUDED
+
+typedef struct cacheray_options {
+  char tracefile[256];
+} cacheray_options_t;
+
+void cacheray_options_init_defaults(cacheray_options_t *options);
+
+/** Parse an options string into a cacheray_options_t.
+ *
+ * Options strings are on the format 'key=value:x=y', i.e. colon-separated
+ * key-value pairs.
+ *
+ * @return non-zero on success.
+ */
+int cacheray_options_parse(const char *optstr, cacheray_options_t *options);
+
+#endif

--- a/cacheray/src/cacheray_options.c
+++ b/cacheray/src/cacheray_options.c
@@ -1,0 +1,96 @@
+#include "cacheray/cacheray_options.h"
+
+#include <assert.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+/** Return a C string containing a copy of the characters in range [begin, end)
+ *
+ * Return value must be deallocated with free().
+ */
+static char *cacheray_options_range_dup(const char *begin, const char *end) {
+  assert(end >= begin);
+
+  size_t len = (end - begin);
+  char *buf = malloc(len + 1);
+  memcpy(buf, begin, len);
+  buf[len] = 0;
+
+  return buf;
+}
+
+static void cacheray_options_set(cacheray_options_t *options, const char *key,
+                                 const char *val) {
+  if (!strcmp(key, "tracefile")) {
+    int r = snprintf(options->tracefile, sizeof(options->tracefile), "%s", val);
+    if (r >= sizeof(options->tracefile)) {
+      fprintf(stderr, "Cacheray: tracefile too long: '%s'\n", val);
+      abort();
+    } else if (r < 0) {
+      fprintf(stderr, "Cacheray: tracefile error %d for '%s'\n", r, val);
+      abort();
+    }
+  } else {
+    fprintf(stderr, "Cacheray: unknown option: '%s'\n", key);
+  }
+}
+
+void cacheray_options_init_defaults(cacheray_options_t *options) {
+  strcpy(options->tracefile, "cacheray.trace");
+}
+
+int cacheray_options_parse(const char *optstr, cacheray_options_t *options) {
+  char *tokstr = NULL;
+  char *key = NULL;
+  char *val = NULL;
+  char *sp;
+
+  // Duplicate the input to get a mutable string
+  tokstr = strdup(optstr);
+  if (!tokstr)
+    goto fail;
+
+  char *optpair = strtok_r(tokstr, ":", &sp);
+  while (optpair) {
+    // optpairs have the following form:
+    //   KEY=VALUE\0
+    // where KEY= and VALUE\0 forms two ranges respectively: [kb,ke) and [vb,ve)
+
+    // Parse key
+    const char *kb = optpair;
+    const char *ke = kb;
+    while (*ke && *ke != '=')
+      ++ke;
+
+    // Parse value
+    const char *vb = ke;
+    if (*vb == '=')
+      ++vb;
+    const char *ve = vb;
+    while (*ve)
+      ++ve;
+
+    // Dupe the ranges into proper C strings
+    key = cacheray_options_range_dup(kb, ke);
+    val = cacheray_options_range_dup(vb, ve);
+    if (!key || !val)
+      goto fail;
+
+    // Update options struct
+    cacheray_options_set(options, key, val);
+
+    free(key);
+    free(val);
+    optpair = strtok_r(NULL, ":", &sp);
+  }
+
+  free(tokstr);
+  return 1;
+
+fail:
+  free(tokstr);
+  free(key);
+  free(val);
+  return 0;
+}

--- a/testbench/run.sh
+++ b/testbench/run.sh
@@ -18,11 +18,11 @@ make --directory=./simple
 make --directory=./reorder
 
 # Create traces
-CACHERAY_FILENAME=good ./simple/simple.out g
-CACHERAY_FILENAME=bad  ./simple/simple.out b
+CACHERAY_OPTIONS=tracefile=good ./simple/simple.out g
+CACHERAY_OPTIONS=tracefile=bad  ./simple/simple.out b
 
-CACHERAY_FILENAME=good-reorder ./reorder/reorder.out g
-CACHERAY_FILENAME=bad-reorder ./reorder/reorder.out b
+CACHERAY_OPTIONS=tracefile=good-reorder ./reorder/reorder.out g
+CACHERAY_OPTIONS=tracefile=bad-reorder ./reorder/reorder.out b
 mv good.0 simple/good.trace
 mv bad.0 simple/bad.trace
 mv good-reorder.0 reorder/good-reorder.trace


### PR DESCRIPTION
Cacheray now accepts a general CACHERAY_OPTIONS environment variable,
instead of just CACHERAY_FILENAME.

The format of CACHERAY_OPTIONS is:

  CACHERAY_OPTIONS=key=val:key2=123

Currently the only known key is `tracefiile` used to designate the
trace output filename. A warning is printed for unknown keys.

Note that the options parser is freestanding and can be used for custom
runtimes (assuming posix/glibc).

Update testbench to use new CACHERAY_OPTIONS env var.