### PR TITLE
Add ability to turn off cacheray before start

### DIFF
--- a/cacheray/include/cacheray/cacheray_options.h
+++ b/cacheray/include/cacheray/cacheray_options.h
@@ -2,6 +2,7 @@
 #define CACHERAY_OPTIONS_H_INCLUDED
 
 typedef struct cacheray_options {
+  int enabled;
   char tracefile[256];
 } cacheray_options_t;
 

--- a/cacheray/src/cacheray.c
+++ b/cacheray/src/cacheray.c
@@ -61,7 +61,7 @@ static void cacheray_init(void) {
     }
 
     atexit(cacheray_shutdown);
-    enabled = 1;
+    enabled = cacheray_opts.enabled;
     is_initialized = 1;
   }
 }

--- a/cacheray/src/cacheray_options.c
+++ b/cacheray/src/cacheray_options.c
@@ -31,6 +31,8 @@ static void cacheray_options_set(cacheray_options_t *options, const char *key,
       fprintf(stderr, "Cacheray: tracefile error %d for '%s'\n", r, val);
       abort();
     }
+  } else if (!strcmp(key, "enabled")) {
+    options->enabled = !!strcmp(val, "0");
   } else {
     fprintf(stderr, "Cacheray: unknown option: '%s'\n", key);
   }
@@ -38,6 +40,7 @@ static void cacheray_options_set(cacheray_options_t *options, const char *key,
 
 void cacheray_options_init_defaults(cacheray_options_t *options) {
   strcpy(options->tracefile, "cacheray.trace");
+  options->enabled = 1;
 }
 
 int cacheray_options_parse(const char *optstr, cacheray_options_t *options) {


### PR DESCRIPTION
The option enabled=false will disable the writing of new trace events to
the tracefile.

One quirk is that a tracefile is still created, but nothing written to it. This behaviour should be kept since in the future, one might start the trace again during execution. 