### PR TITLE
Immediate write

### DIFF
--- a/cacheray/include/cacheray/cacheray.h
+++ b/cacheray/include/cacheray/cacheray.h
@@ -1,19 +1,8 @@
-/*! \file cacheray.h
-    \brief Cacheray structs and defines
+/** Cacheray event type definitions.
+ */
 
-    This file needs to be included to use Cacheray.
-*/
-
-/*! \def LOG_FILE_URL
-    \brief The standard file name for the tracefile.
-*/
-
-/*! \def LOG_FILE_HEADER_LENGTH
-    \brief Length of the header.
-*/
-
-#ifndef __CACHERAY_H__
-#define __CACHERAY_H__
+#ifndef CACHERAY_H_INCLUDED
+#define CACHERAY_H_INCLUDED
 
 typedef unsigned char cacheray_event_t;
 
@@ -22,7 +11,7 @@ typedef unsigned char cacheray_event_t;
 #define CACHERAY_EVENT_RTTA_ADD (cacheray_event_t)(2)
 #define CACHERAY_EVENT_RTTA_REMOVE (cacheray_event_t)(3)
 
-#define CACHERAY_EVENT_MASK_UNALIGNED (cacheray_event_t)(1 << 7)
 #define CACHERAY_EVENT_MASK_ATOMIC (cacheray_event_t)(1 << 6)
+#define CACHERAY_EVENT_MASK_UNALIGNED (cacheray_event_t)(1 << 7)
 
 #endif

--- a/cacheray/include/cacheray/cacheray.h
+++ b/cacheray/include/cacheray/cacheray.h
@@ -25,29 +25,4 @@ typedef unsigned char cacheray_event_t;
 #define CACHERAY_EVENT_MASK_UNALIGNED (cacheray_event_t)(1 << 7)
 #define CACHERAY_EVENT_MASK_ATOMIC (cacheray_event_t)(1 << 6)
 
-/* Memory access events */
-typedef struct __attribute__((__packed__)) cacheray_log_l {
-  cacheray_event_t type;
-  void *addr;
-  unsigned char size;
-  unsigned long threadid; /* big enough to fit a pthread_t :-/ */
-} cacheray_log_t;
-
-/* Run-Time Type Annotation (RTTA) events */
-typedef struct __attribute__((__packed__)) cacheray_rtta_add {
-  cacheray_event_t type;
-  void *addr;
-  unsigned long threadid;
-  unsigned elem_size;
-  unsigned elem_count;
-  unsigned typename_len;
-  char typename[256];
-} cacheray_rtta_add_t;
-
-typedef struct __attribute__((__packed__)) cacheray_rtta_remove {
-  cacheray_event_t type;
-  void *addr;
-  unsigned long threadid;
-} cacheray_rtta_remove_t;
-
 #endif

--- a/cacheray/include/cacheray/cacheray_trace.h
+++ b/cacheray/include/cacheray/cacheray_trace.h
@@ -1,0 +1,36 @@
+#ifndef CACHERAY_TRACE_H_INCLUDED
+#define CACHERAY_TRACE_H_INCLUDED
+
+#include <assert.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <string.h>
+
+static inline void cacheray_put_data(void *fp, const void *v, size_t size) {
+  int res = fwrite(v, size, 1, fp);
+  assert(res == 1);
+}
+
+static inline void cacheray_put_ptr(void *fp, const void *ptr) {
+  cacheray_put_data(fp, &ptr, sizeof(ptr));
+}
+
+static inline void cacheray_put_u8(void *fp, const uint8_t val) {
+  cacheray_put_data(fp, &val, sizeof(val));
+}
+
+static inline void cacheray_put_u32(void *fp, const uint32_t val) {
+  cacheray_put_data(fp, &val, sizeof(val));
+}
+
+static inline void cacheray_put_u64(void *fp, const uint64_t val) {
+  cacheray_put_data(fp, &val, sizeof(val));
+}
+
+static inline void cacheray_put_str(void *fp, const char *val) {
+  uint32_t len = strlen(val);
+  cacheray_put_u32(fp, len);
+  cacheray_put_data(fp, val, len);
+}
+
+#endif

--- a/cacheray/include/cacheray/cacheray_trace.h
+++ b/cacheray/include/cacheray/cacheray_trace.h
@@ -11,6 +11,14 @@ static inline void cacheray_put_data(void *fp, const void *v, size_t size) {
   assert(res == 1);
 }
 
+static inline int cacheray_get_data(void *fp, void *v, size_t size) {
+  return fread(v, size, 1, fp);
+}
+
+static inline void cacheray_skip(void *fp, size_t offset) {
+  fseek(fp, offset, SEEK_CUR);
+}
+
 static inline void cacheray_put_ptr(void *fp, const void *ptr) {
   cacheray_put_data(fp, &ptr, sizeof(ptr));
 }
@@ -31,6 +39,57 @@ static inline void cacheray_put_str(void *fp, const char *val) {
   uint32_t len = strlen(val);
   cacheray_put_u32(fp, len);
   cacheray_put_data(fp, val, len);
+}
+
+static inline int cacheray_get_ptr(void *fp, void **ptr) {
+  return cacheray_get_data(fp, ptr, sizeof(*ptr));
+}
+
+static inline int cacheray_get_u8(void *fp, uint8_t *val) {
+  return cacheray_get_data(fp, val, sizeof(*val));
+}
+
+static inline int cacheray_get_u32(void *fp, uint32_t *val) {
+  return cacheray_get_data(fp, val, sizeof(*val));
+}
+
+static inline int cacheray_get_u64(void *fp, uint64_t *val) {
+  return cacheray_get_data(fp, val, sizeof(*val));
+}
+
+static inline int cacheray_get_str(void *fp, char *buf, size_t size) {
+  uint32_t len;
+  if (!cacheray_get_u32(fp, &len))
+    return 0;
+
+  if (len >= size)
+    return 0;
+
+  if (!cacheray_get_data(fp, buf, len))
+    return 0;
+
+  buf[len] = '\0';
+  return 1;
+}
+
+static inline int cacheray_get_str_trunc(void *fp, char *buf, size_t size) {
+  uint32_t len;
+  if (!cacheray_get_u32(fp, &len))
+    return 0;
+
+  uint32_t tail = 0;
+  if (len >= size) {
+    tail = size - len + 1;
+    len -= tail;
+  }
+
+  if (!cacheray_get_data(fp, buf, len))
+    return 0;
+
+  cacheray_skip(fp, tail);
+
+  buf[len] = '\0';
+  return 1;
 }
 
 #endif


### PR DESCRIPTION
All but eliminate cacheray.h and use more explicit serialization.

(This should make trace serialization faster, and open up for stuff like using network byte order in traces)