### PR TITLE
Fix copy-pasta bug in __tsan_atomic64_fetch_xor

### DIFF
--- a/cacheray/src/cacheray_instrum.inc
+++ b/cacheray/src/cacheray_instrum.inc
@@ -482,8 +482,8 @@ a32 __tsan_atomic32_fetch_xor(volatile a32 *a, a32 v, morder mo) {
 }
 
 a64 __tsan_atomic64_fetch_xor(volatile a64 *a, a64 v, morder mo) {
-  cacheray_log(CACHERAY_EVENT_MASK_ATOMIC | CACHERAY_EVENT_READ, (void *)a, 4);
-  cacheray_log(CACHERAY_EVENT_MASK_ATOMIC | CACHERAY_EVENT_WRITE, (void *)a, 4);
+  cacheray_log(CACHERAY_EVENT_MASK_ATOMIC | CACHERAY_EVENT_READ, (void *)a, 8);
+  cacheray_log(CACHERAY_EVENT_MASK_ATOMIC | CACHERAY_EVENT_WRITE, (void *)a, 8);
   return __atomic_fetch_xor(a, v, to_gcc_mo(mo));
 }
 


### PR DESCRIPTION
The 64-bit fetch_xor should obviously touch 8 bytes, not 4.

Original patch by @gandalfnisse

(closes issue #23)